### PR TITLE
WIP: Replace wpa_supplicant with IWD

### DIFF
--- a/dockerfiles/uos/dockerfiles/wlan/Dockerfile
+++ b/dockerfiles/uos/dockerfiles/wlan/Dockerfile
@@ -10,10 +10,12 @@ RUN apk add --no-cache \
     inotify-tools \
     tini \
     wireless-tools \
-    wpa_supplicant 
+    iwd \
+    dbus
 
 COPY init.sh /usr/local/bin/init.sh
-COPY wpa_supplicant.conf.template /opt/wpa_supplicant.conf.template
+COPY iwd.conf.template /opt/iwd.conf.template
+COPY iwd.main.template /etc/iwd/
 
 WORKDIR /
 

--- a/dockerfiles/uos/dockerfiles/wlan/init.sh
+++ b/dockerfiles/uos/dockerfiles/wlan/init.sh
@@ -1,89 +1,44 @@
 #!/bin/bash
-
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
+# --- Get kernel parameters ---
+
+rm /var/run/dbus.pid
+
+dbus-daemon --system &
+sleep 1
 
 # --- Get kernel parameters ---
 kernel_params=$(cat /proc/cmdline)
 
-if [[ $kernel_params == *"wpacountry="* ]]; then
-	tmp="${kernel_params##*wpacountry=}"
-	COUNTRY="${tmp%% *}"
-fi
-
 if [[ $kernel_params == *"wpassid="* ]]; then
-	tmp="${kernel_params##*wpassid=}"
-	 SSID="${tmp%% *}"
+       tmp="${kernel_params##*wpassid=}"
+       SSID="${tmp%% *}"
 fi
 
 if [[ $kernel_params == *"wpapsk="* ]]; then
-	tmp="${kernel_params##*wpapsk=}"
-	PSK="${tmp%% *}"
+       tmp="${kernel_params##*wpapsk=}"
+       PSK="${tmp%% *}"
 fi
 
-configdir="/run/wpa_supplicant"
-configfile="/etc/wpa_supplicant/wpa_supplicant.conf"
-configfileTemplate="/opt/wpa_supplicant.conf.template"
+configdir="/var/lib/iwd"
+configfile="/var/lib/iwd/$SSID.psk"
+configfileTemplate="/opt/iwd.conf.template"
 
-mkdir -p /etc/wpa_supplicant
+mkdir -p /var/lib/iwd
 
 cp ${configfileTemplate} ${configfile}
 
-sed -i -e "s/@@COUNTRY@@/${COUNTRY}/g" ${configfile}
-
 if [ -d "/sys/class/ieee80211" ]; then
-  # Note: Can't use wpa_supplicant without WPA; have to disable it then e.g.,
-  # iwconfig wlan0 essid "ietf-hotel"
-
-  if ( ip link show mlan0 > /dev/null 2>&1 ); then 
-    # workaround for mlan0 driver of Advantech
-    (ip link set mlan0 down ; ip link set mlan0 name wlan0) || /bin/true
-  fi
-  if (! ip link show wlan0 | grep up > /dev/null ); then
-    ip link set wlan0 up
-  fi
-
   if [ -n "${SSID}" ] && [ -n "${PSK}" ]; then
     cp ${configfileTemplate} ${configfile}
 
-    sed -i -e "s/@@COUNTRY@@/${COUNTRY}/g" ${configfile}
-    sed -i -e "s/@@SSID@@/${SSID}/g" ${configfile}
     sed -i -e "s/@@PSK@@/${PSK}/g" ${configfile}
 
     if [ -d "${configdir}" ] && [ -f "${configfile}" ]; then
-      wpa_supplicant -Dwext -iwlan0 -c "${configfile}" -d -B && \
-      sleep 1.5 && \
-      udhcpc -i wlan0 && \
-      cat /etc/resolv.conf > /etc/system-resolv.conf
+      /usr/libexec/iwd -d
     fi
   fi
 fi
 
-while inotifywait -e modify ${configfile}; do 
-  echo "${configfile} has changed. Restarting services"
-  if [ -d "/sys/class/ieee80211" ]; then
-    # Note: Can't use wpa_supplicant without WPA; have to disable it then e.g.,
-    # iwconfig wlan0 essid "ietf-hotel"
 
-    if ( ip link show mlan0 > /dev/null 2>&1 ); then 
-      # workaround for mlan0 driver of Advantech
-      (ip link set mlan0 down ; ip link set mlan0 name wlan0) || /bin/true
-    fi
-    if (! ip link show wlan0 | grep up > /dev/null ); then
-      ip link set wlan0 up
-    fi
-    if [ -z "$(pgrep -x "wpa_supplicant")" ]; then
-      wpa_supplicant -Dwext -iwlan0 -c "${configfile}" -d -B && \
-      sleep 1.5 && \
-      udhcpc -i wlan0 && \
-      cat /etc/resolv.conf > /etc/system-resolv.conf
-    else
-      killall -s HUP wpa_supplicant && \
-      sleep 1.5 && \
-      udhcpc -i wlan0 && \
-      cat /etc/resolv.conf > /etc/system-resolv.conf
-    fi
-  else
-    echo "No wireless devices found.  Sleeping until restarted."
-  fi
-done

--- a/dockerfiles/uos/dockerfiles/wlan/iwd.conf.template
+++ b/dockerfiles/uos/dockerfiles/wlan/iwd.conf.template
@@ -1,0 +1,3 @@
+[Security]
+Passphrase=@@PSK@@
+

--- a/dockerfiles/uos/dockerfiles/wlan/iwd.main.template
+++ b/dockerfiles/uos/dockerfiles/wlan/iwd.main.template
@@ -1,0 +1,5 @@
+[General]
+EnableNetworkConfiguration=true
+
+[Network]
+NameResolvingService=resolvconf

--- a/dockerfiles/uos/uos-wifi.yml
+++ b/dockerfiles/uos/uos-wifi.yml
@@ -35,6 +35,8 @@ services:
       - /sys:/sys
       - /run/resolvconf/resolv.conf:/etc/system-resolv.conf
       - /var/services/wlan:/etc
+      - /etc/sshd.passwd:/etc/passwd
+      - /etc/sshd.group:/etc/group
     runtime:
         mkdir: ["/var/services/wlan"]
   - name: getty
@@ -206,6 +208,7 @@ files:
       guest:x:405:100:guest:/dev/null:/sbin/nologin
       nobody:x:65534:65534:nobody:/:/sbin/nologin
       uos:x:1000:1000:uos:/home/uos:/bin/ash
+      messagebus:x:27:27:D-Bus User:/dev/null:/bin/false
     mode: "644"
   - path: etc/sshd.group
     contents: |
@@ -257,4 +260,5 @@ files:
       nogroup:x:65533:
       nobody:x:65534:
       uos:x:1000:
+      messagebus:x:27:
     mode: "644"


### PR DESCRIPTION
This removes the wpa_supplicant dependency and replaces IWD as the wifi management daemon. The dbus package was required to use IWD which was also added.

Several additions to the wlan container:
 - Bind /etc/sshd.passwd to /etc/passwd
 - Bind /etc/sshd.group to /etc/passwd
 - Create messagebus user/group

TODO:
 - Run DBus in its own container, and expose the socket for the wlan container. This would allow IWD to be controlled with iwctl from outside the wlan container.
 - Set wpapsk to proper key in IWD config. Currently set to [Security].Passphrase which was more convenient for testing. This should be [Security].PreSharedKey instead.
 - Currently wpassid/wpapsk are not present in kernel config and I have been manually adding them into init.sh to test. Likely a build issue on my end.
 - Create /etc/iwd/main.conf. The template iwd.main.template is not showing up in /etc/iwd/main.conf. This will enable IWD to do DHCP.
 - Bind /usr/sbin/resolvconf to wlan container. This did not work adding to the bind list, and the wlan container would not start. This will allow IWD to use resolvconf for DNS automatically.